### PR TITLE
Fix blocking image observer

### DIFF
--- a/samcli/lib/utils/file_observer.py
+++ b/samcli/lib/utils/file_observer.py
@@ -307,12 +307,12 @@ class ImageObserver(ResourceObserver):
         self._observed_images: Dict[str, str] = {}
         self._input_on_change: Callable = on_change
         self.docker_client: DockerClient = docker.from_env(version=DOCKER_MIN_API_VERSION)
-        self.events: CancellableStream = self.docker_client.events(filters={"type": "image"}, decode=True)
         self._images_observer_thread: Optional[Thread] = None
         self._lock: Lock = threading.Lock()
 
     @broken_pipe_handler
     def _watch_images_events(self):
+        self.events: CancellableStream = self.docker_client.events(filters={"type": "image"}, decode=True)
         for event in self.events:
             if event.get("Action", None) != "tag":
                 continue


### PR DESCRIPTION
I'm not very good with python but I figured this should fix some issues happening when running locally with Podman.

#### Which issue(s) does this change fix?
https://github.com/aws/aws-sam-cli/issues/7298


#### Why is this change necessary?
Calling the events function from the main thread will block until it receives data as docker-py uses urllib3.openurl under the hood which is blocking (read).

#### How does it address the issue?
We don't want to block the main thread, so moving the self.events assignment in a thread seems to be the solution.


#### What side effects does this change have?
I can't see any side effect this would introduce.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
